### PR TITLE
Attestation workflow permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
+      contents: write
     steps:
       - name: Download packages
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8


### PR DESCRIPTION
- Add pypi trusted publisher workflow
- fix trusted pub workflow (for attestation)
- Attestation permissions
